### PR TITLE
`getNextNumPyFrame`: Change numpy array bytesize calculation

### DIFF
--- a/pixelinkWrapper/pixelink.py
+++ b/pixelinkWrapper/pixelink.py
@@ -1240,7 +1240,7 @@ class PxLApi:
             if(not(PxLApi.apiSuccess(rc))):
                 return (rc,)
         else:
-            ctBufferSize = frame.size
+            ctBufferSize = frame.size * frame.itemsize
             rc = PxLApi._Api.PxLGetNextFrame(hCamera, ctBufferSize, frame.ctypes.data_as(c_void_p), byref(ctFrameDesc))
             if (not(PxLApi.apiSuccess(rc))):
                 return (rc,)


### PR DESCRIPTION
When using a 16 bit pixel format and supplying `getNextNumPyFrame` a `np.zeros((2048, 2048), dtype=np.uint16)` frame buffer, pixelink thinks that the array is too small. Supplying `np.zeros((2048,2048*2), dtype=np.uint8)` like used by the examples works, but makes less sense to me.
I thus added the array element bytesize to the buffer size calculation.

I'm aware that afterwards I've to call numpy's `byteswap` function for big/little endian conversion.